### PR TITLE
Remove unused billing lbrary

### DIFF
--- a/ModernScrambledNet/build.gradle
+++ b/ModernScrambledNet/build.gradle
@@ -25,6 +25,5 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui:2.3.5'
     implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.4.0'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.0'
-    implementation "com.android.billingclient:billing-ktx:4.0.0"
     implementation 'androidx.preference:preference:1.1.1'
 }


### PR DESCRIPTION
Presumably this is a leftover from a previous version that had in game purchases, nothing references it now.