### PR TITLE
Remove custom screen size options

### DIFF
--- a/ModernScrambledNet/src/main/java/com/jimnastic/modernscramblednet/BoardView.java
+++ b/ModernScrambledNet/src/main/java/com/jimnastic/modernscramblednet/BoardView.java
@@ -201,14 +201,6 @@ public class BoardView
 
         int width = display.widthPixels;
         int height = display.heightPixels;
-        Integer customWidth = SettingsActivity.EasyWidth;
-        Integer customHeight = SettingsActivity.EasyHeight;
-
-        if (customWidth != null)
-            Screen.HUGE.major = customWidth;
-        if (customHeight != null)
-            Screen.HUGE.minor = customHeight;
-
 
         if (width > height)
         {
@@ -392,6 +384,9 @@ public class BoardView
     {
         // Save the width and height of the playing board for this skill level, and the board
         // placement within the overall cell grid
+	// The grid sizes are the total number of cells on the screen and match the largest
+	// possible board size for the current screen size (currently always HUGE), the board
+	// sizes are the number of cells used in the current level
         boardWidth = Screen.HUGE.getBoardWidth(sk, gridWidth, gridHeight);
         boardHeight = Screen.HUGE.getBoardHeight(sk, gridWidth, gridHeight);
         boardStartX = (gridWidth - boardWidth) / 2;

--- a/ModernScrambledNet/src/main/java/com/jimnastic/modernscramblednet/MainActivity.java
+++ b/ModernScrambledNet/src/main/java/com/jimnastic/modernscramblednet/MainActivity.java
@@ -68,11 +68,6 @@ public class MainActivity extends AppCompatActivity
 
         SharedPreferences newPrefs = PreferenceManager.getDefaultSharedPreferences(this);
 
-        /* **** Custom board size Setup *****/
-        SettingsActivity.EasyHeight = Integer.parseInt(newPrefs.getString("EasyHeightPreference","5"));
-        SettingsActivity.EasyWidth = Integer.parseInt(newPrefs.getString("EasyWidthPreference","5"));
-        /* **** End custom board size Setup *****/
-
         // Create the GUI for the game
         Log.i(TAG, "MainActivity.onCreate().setContentView() using R.layout.mainactivity");
         Log.i(TAG, "**************************************************************");

--- a/ModernScrambledNet/src/main/java/com/jimnastic/modernscramblednet/SettingsActivity.java
+++ b/ModernScrambledNet/src/main/java/com/jimnastic/modernscramblednet/SettingsActivity.java
@@ -15,8 +15,6 @@ import androidx.preference.PreferenceFragmentCompat;
 
 public class SettingsActivity extends AppCompatActivity
 {
-    public static Integer EasyHeight;
-    public static Integer EasyWidth;
     public static boolean AnimationState;
     public static String SoundString;
     public static MainActivity.SoundMode SoundState()
@@ -53,8 +51,6 @@ public class SettingsActivity extends AppCompatActivity
 
             Preference animation = findPreference("AnimationPreference");
             Preference sound = findPreference("SoundPreference");
-            Preference easyHeight = findPreference("EasyHeightPreference");
-            Preference easyWidth = findPreference("EasyWidthPreference");
 
             assert animation != null;
             animation.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
@@ -76,17 +72,6 @@ public class SettingsActivity extends AppCompatActivity
                 }
             });
 
-            easyHeight.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener()
-            {
-                @Override
-                public boolean onPreferenceChange(Preference preference, Object newValue)
-                {
-                    EasyHeight = Integer.parseInt(newValue.toString());
-                    Log.i(MainActivity.TAG,"EasyHeight setting has been changed to: " + EasyHeight);
-
-                    return true;
-                }
-            });
         }
     }
 }

--- a/ModernScrambledNet/src/main/res/xml/root_preferences.xml
+++ b/ModernScrambledNet/src/main/res/xml/root_preferences.xml
@@ -18,15 +18,6 @@
         android:key="BoardSizePreference"
         app:title="@string/boardsize_header">
 
-        <EditTextPreference
-            android:key="EasyHeightPreference"
-            android:title="Easy Height"
-            app:useSimpleSummaryProvider="true" />
-        <EditTextPreference
-            android:key="EasyWidthPreference"
-            android:title="Easy Width"
-            app:useSimpleSummaryProvider="true" />
-
         <!--EditTextPreference
             app:key="Normal"
             app:title="@string/skill_normal"


### PR DESCRIPTION
The custom grid sizes didn't include any checks that they were big
enough to accommodate the board and larger sizes don't really work
on wrapped levels